### PR TITLE
FreeBSD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 *.pyc
+*.swp
 .tmp/
 .vagrant
 Gemfile.lock

--- a/hiera/FreeBSD.yaml
+++ b/hiera/FreeBSD.yaml
@@ -1,0 +1,3 @@
+---
+file_cache_dir: /tmp
+installer_staging_dir: /tmp/vagrant-temp

--- a/modules/autotools/manifests/init.pp
+++ b/modules/autotools/manifests/init.pp
@@ -84,6 +84,7 @@ define autotools(
     command     => "sh ${real_configure_file} ${configure_flags}",
     creates     => $real_configure_sentinel,
     cwd         => $cwd,
+    provider    => shell,
     environment => $exec_environment,
   }
 

--- a/modules/bsdtar/manifests/init.pp
+++ b/modules/bsdtar/manifests/init.pp
@@ -8,7 +8,7 @@ class bsdtar(
   $file_cache_dir = params_lookup('file_cache_dir', 'global'),
 ) {
   case $kernel {
-    'Darwin', 'Linux': { include bsdtar::posix }
+    'Darwin', 'Linux', 'FreeBSD': { include bsdtar::posix }
     'windows': { include bsdtar::windows }
     default: { fail("Unknown operating system to install bsdtar.") }
   }

--- a/modules/bsdtar/manifests/posix.pp
+++ b/modules/bsdtar/manifests/posix.pp
@@ -72,9 +72,9 @@ class bsdtar::posix {
 
   # Build it
   autotools { "libarchive":
-    configure_flags  => "--prefix=${install_dir} --disable-dependency-tracking --with-zlib --without-bz2lib --without-lzmadec --without-iconv --without-libiconv-prefix --without-lzma --without-nettle --without-openssl --without-xml2 --without-expat --without-libregex",
+    configure_flags  => "--prefix=${install_dir} --disable-dependency-tracking --with-zlib --without-bz2lib --without-lzmadec --without-iconv --without-libiconv-prefix --without-lzma --without-nettle --without-openssl --without-xml2 --without-expat",
     cwd              => $source_dir_path,
-    environment      => $real_autotools_environment,
+    #environment      => $real_autotools_environment,
     install_sentinel => "${install_dir}/bin/bsdtar",
     make_sentinel    => "${source_dir_path}/bsdtar",
     require          => Exec["automake-libarchive"],

--- a/modules/curl/manifests/init.pp
+++ b/modules/curl/manifests/init.pp
@@ -8,7 +8,7 @@ class curl(
   $file_cache_dir = params_lookup('file_cache_dir', 'global'),
 ) {
   case $kernel {
-    'Darwin', 'Linux': { include curl::posix }
+    'Darwin', 'Linux', 'FreeBSD': { include curl::posix }
     'windows':         { include curl::windows }
     default: { fail("Unknown OS to install cURL") }
   }

--- a/modules/curl/manifests/posix.pp
+++ b/modules/curl/manifests/posix.pp
@@ -5,7 +5,7 @@ class curl::posix {
   $file_cache_dir        = $curl::file_cache_dir
   $install_dir           = $curl::install_dir
 
-  $source_filename  = "curl-7.33.0.tar.gz"
+  $source_filename  = "curl-7.34.0.tar.gz"
   $source_url = "http://curl.haxx.se/download/${source_filename}"
   $source_file_path = "${file_cache_dir}/${source_filename}"
   $source_dir_name  = regsubst($source_filename, '^(.+?)\.tar\.gz$', '\1')
@@ -17,6 +17,11 @@ class curl::posix {
     $extra_autotools_environment = {
       "CFLAGS"  => "-arch i386",
       "LDFLAGS" => "-arch i386 -Wl,-rpath,${install_dir}/lib",
+    }
+  } elsif $operatingsystem == 'FreeBSD' {
+    $extra_autotools_environment = {
+      "CFLAGS"  => '-fPIC',
+      "LD_RUN_PATH" => "${install_dir}/lib",
     }
   } else {
     $extra_autotools_environment = {

--- a/modules/download/manifests/init.pp
+++ b/modules/download/manifests/init.pp
@@ -5,8 +5,8 @@
 #
 define download($source, $destination) {
   case $kernel {
-    'Darwin', 'Linux': {
-      # On Mac and Linux we use wget
+    'Darwin', 'Linux', 'FreeBSD': {
+      # On Mac, Linux, and FreeBSD we use wget
       wget::fetch { $name:
         source      => $source,
         destination => $destination,

--- a/modules/libffi/manifests/init.pp
+++ b/modules/libffi/manifests/init.pp
@@ -10,7 +10,7 @@ class libffi (
 ) {
   require build_essential
 
-  $source_filename  = "libffi-3.0.11.tar.gz"
+  $source_filename  = "libffi-3.0.13.tar.gz"
   $source_file_path = "${file_cache_dir}/${source_filename}"
   $source_dir_name  = regsubst($source_filename, '^(.+?)\.tar\.gz$', '\1')
   $source_dir_path  = "${file_cache_dir}/${source_dir_name}"

--- a/modules/libyaml/manifests/init.pp
+++ b/modules/libyaml/manifests/init.pp
@@ -23,6 +23,10 @@ class libyaml(
       "CFLAGS"  => "-arch i386 -arch x86_64",
       "LDFLAGS" => "-arch i386 -arch x86_64",
     }
+  } elsif $operatingsystem == 'FreeBSD' {
+    $extra_autotools_environment = {
+      "CFLAGS"  => '-fPIC',
+    }
   } else {
     $extra_autotools_environment = {}
   }

--- a/modules/readline/manifests/init.pp
+++ b/modules/readline/manifests/init.pp
@@ -23,6 +23,10 @@ class readline(
       "CFLAGS"  => "-arch i386 -arch x86_64",
       "LDFLAGS" => "-arch i386 -arch x86_64",
     }
+  } elsif $operatingsystem == 'FreeBSD' {
+    $extra_autotools_environment = {
+      "CFLAGS"  => '-fPIC',
+    }
   } else {
     $extra_autotools_environment = {}
   }

--- a/modules/vagrant/manifests/init.pp
+++ b/modules/vagrant/manifests/init.pp
@@ -14,7 +14,7 @@ class vagrant(
   }
 
   $gem_renamer = path("${file_cache_dir}/vagrant_gem_rename.rb")
-  $source_url = "https://github.com/mitchellh/vagrant/archive/${revision}.${extension}"
+  $source_url = "https://github.com/mitchellh/vagrant/archive/v${revision}.${extension}"
   $source_file_path = path("${file_cache_dir}/vagrant-${revision}.${extension}")
   $source_dir_path  = path("${file_cache_dir}/vagrant-${revision}")
   $vagrant_gem_path = path("${source_dir_path}/vagrant.gem")

--- a/modules/vagrant_installer/manifests/package.pp
+++ b/modules/vagrant_installer/manifests/package.pp
@@ -9,6 +9,7 @@ class vagrant_installer::package {
     'Darwin': { include vagrant_installer::package::darwin }
     'Ubuntu': { include vagrant_installer::package::ubuntu }
     'windows': { include vagrant_installer::package::windows }
+    'FreeBSD': { include vagrant_installer::package::freebsd }
     default:  { fail("Unknown operating system to package for.") }
   }
 }

--- a/modules/vagrant_installer/manifests/package/freebsd.pp
+++ b/modules/vagrant_installer/manifests/package/freebsd.pp
@@ -1,0 +1,59 @@
+# == Class: vagrant_installer::package::freebsd
+#
+# This creates a package for Vagrant for FreeBSD.
+#
+class vagrant_installer::package::freebsd {
+  # This feels dirty.
+  require vagrant_installer::package::linux
+
+  $file_cache_dir = hiera("file_cache_dir")
+  $dist_dir      = $vagrant_installer::params::dist_dir
+  $staging_dir    = $vagrant_installer::params::staging_dir
+  $vagrant_version = $vagrant_installer::params::vagrant_version
+
+  $pkgname = "vagrant"
+  $pkgver  = $vagrant_version
+  $setup_dir = "${file_cache_dir}/freebsd_setup"
+  $source_package = "vagrant.tar.gz"
+
+  $final_output_path = "${dist_dir}/vagrant_${vagrant_version}_${hardwaremodel}.txz"
+
+  #------------------------------------------------------------------
+  # Setup the working directory we'll use
+  #------------------------------------------------------------------
+  exec { "clear-freebsd-setup-dir":
+    command => "rm -rf ${setup_dir}",
+  }
+
+  util::recursive_directory { $setup_dir:
+    require => Exec["clear-freebsd-setup-dir"],
+  }
+
+  file { $setup_dir:
+    ensure  => directory,
+    owner   => "root",
+    group   => "wheel",
+    mode    => "0755",
+    require => Util::Recursive_directory[$setup_dir],
+  }
+
+  #------------------------------------------------------------------
+  # Package
+  #------------------------------------------------------------------
+
+  # Create the +MANIFEST file so we can create a binary package
+  file { "${setup_dir}/+MANIFEST":
+    content => template("vagrant_installer/package/freebsd_pkgbuild.erb"),
+    owner   => "root",
+    group   => "wheel",
+    mode    => "0644",
+    require => File[$setup_dir],
+  }
+
+  # Create the binary package
+  exec { "createpkg":
+    command => "pkg create -m $setup_dir",
+    cwd     => $setup_dir,
+    require => File["${setup_dir}/+MANIFEST"],
+  }
+}

--- a/modules/vagrant_installer/manifests/staging.pp
+++ b/modules/vagrant_installer/manifests/staging.pp
@@ -13,13 +13,13 @@ class vagrant_installer::staging {
   $archive_path = "${dist_dir}${file_sep}${archive_name}.zip"
 
   case $kernel {
-    'Darwin', 'Linux': { include vagrant_installer::staging::posix }
+    'Darwin', 'Linux', 'FreeBSD': { include vagrant_installer::staging::posix }
     'windows': { include vagrant_installer::staging::windows }
     default:   { fail("Unknown operating system to stage.") }
   }
 
   case $kernel {
-    'Darwin', 'Linux': {
+    'Darwin', 'Linux', 'FreeBSD': {
       include zip
 
       $archive_staging_dir = "${staging_dir}/${archive_name}"
@@ -36,9 +36,10 @@ class vagrant_installer::staging {
       }
 
       exec { "archive-installer":
-        command => "/usr/bin/zip -r ${archive_path} ${archive_name}/",
+        command => "zip -r ${archive_path} ${archive_name}/",
         creates => $archive_path,
         cwd     => $staging_dir,
+        path    => ['/usr/bin', '/usr/local/bin'],
         require => [
           Class["zip"],
           Exec["copy-archive-contents"],

--- a/modules/vagrant_installer/templates/package/freebsd_pkgbuild.erb
+++ b/modules/vagrant_installer/templates/package/freebsd_pkgbuild.erb
@@ -1,15 +1,16 @@
 name: <%= @pkgname %>
 version: <%= @pkgver %>
-origin: emulators/vagrant
-comment: Vagrant package
 arch: freebsd:9:x86:64
-www: http://www.vagrantup.com
-maintainer: HashiCorp <biz@hashicorp.com>
+origin: emulators/<%= @pkgname %>
+comment: Vagrant is a tool for building complete development environments
+desc: Vagrant is a tool for building complete development environments
+www: http://www.vagrantup.com/
+maintainer: biz@hashicorp.com
 prefix: /
-licenselogic: MIT
-desc: |-
-  Vagrant
+deps: 
 categories: [emulators]
-files:
-dirs:
-- /usr/local/vagrant
+licenselogic: single
+licenses: [MIT]
+users: []
+groups: []
+options: {}

--- a/modules/vagrant_installer/templates/package/freebsd_pkgbuild.erb
+++ b/modules/vagrant_installer/templates/package/freebsd_pkgbuild.erb
@@ -1,6 +1,6 @@
 name: <%= @pkgname %>
 version: <%= @pkgver %>
-arch: freebsd:9:x86:64
+arch: freebsd:10:x86:64
 origin: emulators/<%= @pkgname %>
 comment: Vagrant is a tool for building complete development environments
 desc: Vagrant is a tool for building complete development environments

--- a/modules/vagrant_installer/templates/package/freebsd_pkgbuild.erb
+++ b/modules/vagrant_installer/templates/package/freebsd_pkgbuild.erb
@@ -1,0 +1,15 @@
+name: <%= @pkgname %>
+version: <%= @pkgver %>
+origin: emulators/vagrant
+comment: Vagrant package
+arch: freebsd:9:x86:64
+www: http://www.vagrantup.com
+maintainer: HashiCorp <biz@hashicorp.com>
+prefix: /
+licenselogic: MIT
+desc: |-
+  Vagrant
+categories: [emulators]
+files:
+dirs:
+- /usr/local/vagrant

--- a/modules/wget/manifests/fetch.pp
+++ b/modules/wget/manifests/fetch.pp
@@ -18,8 +18,9 @@ define wget::fetch($source=$name, $destination) {
   require wget
 
   exec { "wget-${name}":
-    command => "wget --output-document=${destination} ${source}",
+    command => "wget --no-check-certificate --output-document=${destination} ${source}",
     creates => $destination,
     timeout => 1200,
+    path    => $::path,
   }
 }

--- a/modules/wget/manifests/init.pp
+++ b/modules/wget/manifests/init.pp
@@ -8,9 +8,14 @@ class wget {
     homebrew::package { "wget":
       creates     => "/usr/local/bin/wget",
     }
-  } else {
+  } elsif $operatingsystem == 'FreeBSD' {
     package { "wget":
-      ensure => installed,
+      ensure   => installed,
+      provider => pkgng,
+    }
+  } else { 
+    package { "wget":
+      ensure   => installed,
     }
   }
 }

--- a/modules/zip/manifests/init.pp
+++ b/modules/zip/manifests/init.pp
@@ -2,7 +2,13 @@ class zip {
   case $operatingsystem {
     'Ubuntu': {
       package { ["zip", "unzip"]:
-        ensure => installed,
+        ensure   => installed,
+      }
+    }
+    'FreeBSD': {
+      package { ["zip", "unzip"]:
+        ensure   => installed,
+        provider => pkgng,
       }
     }
   }

--- a/modules/zlib/manifests/init.pp
+++ b/modules/zlib/manifests/init.pp
@@ -23,6 +23,10 @@ class zlib(
       "CFLAGS"  => "-arch i386 -arch x86_64",
       "LDFLAGS" => "-arch i386 -arch x86_64",
     }
+  } elsif $operatingsystem == 'FreeBSD' {
+    $extra_autotools_environment = {
+      "CFLAGS"  => '-fPIC',
+    }
   } else {
     $extra_autotools_environment = {}
   }

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script will actually run the puppet code here.
 


### PR DESCRIPTION
This is an attempt at adding FreeBSD support to the build system.  I'm sure we've made a few mistakes, and there's a few issues left to resolve:

From Pawel Tomulik who helped me push this over the finish line to a working package:

    things to consider:

      - I don't know what I'm doing :) , but:
      - it seems that vagrant-installers is self contained and needs no
        dependencies, if hower it do need some external packages, these
        should be listed under `deps:` in +MANIFEST,
      - currently vagrant installs into `/opt` which is bad choice for
        FreeBSD IMHO, should land somewhere within `/usr/local`,
      - don't know why, but it also builds a `*.zip` file in the dist
        directory,

    How to proceed:

         ./run 1.4.2 1.4.2 /tmp/test
         pkg add /tmp/test/vagrant-1.4.2.txz
         LD_LIBRARY_PATH=/opt/vagrant/embedded/lib vagrant

    Of course, the LD_LIBRARY_PATH=.. is a workaround. It should be fixed
    somehow.

I wanted to get this in for an early review/help from people that know what they are doing.