### PR TITLE
Add URL to fpm flags when creating a .deb package

### DIFF
--- a/package/support/package_ubuntu.sh
+++ b/package/support/package_ubuntu.sh
@@ -42,6 +42,7 @@ fpm -p ${OUTPUT_PATH} \
   -t deb \
   --prefix '/' \
   --maintainer "HashiCorp <hello@hashicorp.com>" \
+  --url "http://vagrantup.com/" \
   --epoch 1 \
   --deb-user root \
   --deb-group root \


### PR DESCRIPTION
The current .deb package has a default "placeholder" URL in it, which can be seen in `apt-cache show vagrant` output:
```
Package: vagrant
Status: install ok installed
Priority: extra
Section: default
Installed-Size: 176193
Maintainer: HashiCorp <hello@hashicorp.com>
Architecture: amd64
Version: 1:1.7.2
Description: no description given
Description-md5: c0af8b65ef8df63b3bfb124d96da1778
License: unknown
Vendor: root@vagrant-package-ubuntu-64
Homepage: http://example.com/no-uri-given
``` 
As far as I can see, `fpm` supports passing a home page URL via the `--url` parameter, which is all that this commit adds.

I've tried to test it by packaging a copy of .deb myself, but I can't seem to figure out how to build one. Any nudge in the right direction would be appreciated. Sorry for not testing this before submitting a pull request, but I've been poking around the scripts and I can't seem to find the proper lever to pull in order to get it working. :)

Hope you're having a great day!