### PR TITLE
add scp/sftp support to curl on ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Gemfile.lock
 Thumbs.db
 cache
 dist
+package/package-staging
 packer/packer_cache
 packer/var-file.json
 substrate/launcher/launcher.exe

--- a/substrate/modules/build_essential/manifests/init.pp
+++ b/substrate/modules/build_essential/manifests/init.pp
@@ -39,7 +39,7 @@ class build_essential {
 
     'Ubuntu': {
       package {
-        ["build-essential", "autoconf", "automake", "chrpath", "libtool"]:
+        ["build-essential", "autoconf", "automake", "chrpath", "libtool", "pkg-config"]:
           ensure => installed,
       }
     }

--- a/substrate/modules/curl/manifests/posix.pp
+++ b/substrate/modules/curl/manifests/posix.pp
@@ -21,6 +21,7 @@ class curl::posix {
   } else {
     $extra_autotools_environment = {
       "LD_RUN_PATH" => "${install_dir}/lib",
+      "PKG_CONFIG_PATH" => "${install_dir}/lib/pkgconfig",
     }
   }
 
@@ -44,7 +45,7 @@ class curl::posix {
   }
 
   autotools { "curl":
-    configure_flags    => "--prefix=${install_dir} --disable-dependency-tracking --disable-ldap",
+    configure_flags    => "--prefix=${install_dir} --disable-dependency-tracking --disable-ldap --with-libssh2",
     configure_sentinel => "${source_dir_path}/src/Makefile",
     cwd                => $source_dir_path,
     environment        => $real_autotools_environment,

--- a/substrate/modules/libssh2/manifests/init.pp
+++ b/substrate/modules/libssh2/manifests/init.pp
@@ -1,0 +1,61 @@
+# == Class: libssh2
+#
+# This installs the libssh2 library from source.
+#
+class libssh2(
+  $autotools_environment = {},
+  $file_cache_dir = params_lookup('file_cache_dir', 'global'),
+  $make_notify = undef,
+  $prefix = params_lookup('prefix'),
+) {
+  require build_essential
+
+  $version  = "1.6.0"
+  $source_filename  = "libssh2-${version}.tar.gz"
+  $source_url = "https://github.com/libssh2/libssh2/releases/download/libssh2-${version}/${source_filename}"
+  $source_file_path = "${file_cache_dir}/${source_filename}"
+  $source_dir_name  = regsubst($source_filename, '^(.+?)\.tar\.gz$', '\1')
+  $source_dir_path  = "${file_cache_dir}/${source_dir_name}"
+
+  # Determine if we have an extra environmental variables we need to set
+  # based on the operating system.
+  if $operatingsystem == 'Darwin' {
+    $extra_autotools_environment = {
+      "CFLAGS"  => "-arch i386 -arch x86_64",
+      "LDFLAGS" => "-arch i386 -arch x86_64",
+    }
+  } else {
+    $extra_autotools_environment = {
+      "PKG_CONFIG_PATH" => "${install_dir}/lib/pkgconfig",
+    }
+  }
+
+  # Merge our environments.
+  $real_autotools_environment = autotools_merge_environments(
+    $autotools_environment, $extra_autotools_environment)
+
+  #------------------------------------------------------------------
+  # Compile
+  #------------------------------------------------------------------
+  wget::fetch { "libssh2":
+    source      => $source_url,
+    destination => $source_file_path,
+  }
+
+  exec { "untar-libssh2":
+    command => "tar xvzf ${source_file_path}",
+    creates => $source_dir_path,
+    cwd     => $file_cache_dir,
+    require => Wget::Fetch["libssh2"],
+  }
+
+  autotools { "libssh2":
+    configure_flags  => "--prefix=${prefix} --with-libssl-prefix=${prefix}",
+    cwd              => $source_dir_path,
+    environment      => $real_autotools_environment,
+    install_sentinel => "${prefix}/lib/libssh2.a",
+    make_notify      => $make_notify,
+    make_sentinel    => "${source_dir_path}/src/.libs/libssh2.a",
+    require          => Exec["untar-libssh2","make-install-openssl"],
+  }
+}

--- a/substrate/modules/vagrant_substrate/manifests/staging/posix.pp
+++ b/substrate/modules/vagrant_substrate/manifests/staging/posix.pp
@@ -108,6 +108,14 @@ class vagrant_substrate::staging::posix {
       require        => Class["libiconv"],
   }
 
+  class { "libssh2":
+    autotools_environment => autotools_merge_environments(
+      $default_autotools_environment, $libssh2_autotools_environment),
+      file_cache_dir => $cache_dir,
+      prefix         => $embedded_dir,
+      require        => Class["openssl"],
+  }
+
   class { "libxslt":
     autotools_environment => $default_autotools_environment,
     file_cache_dir        => $cache_dir,
@@ -172,6 +180,7 @@ class vagrant_substrate::staging::posix {
     install_dir           => $embedded_dir,
     require               => [
       Class["openssl"],
+      Class["libssh2"],
       Class["zlib"],
     ],
   }


### PR DESCRIPTION
Related to #30 but this is only for Ubuntu right now. I had to build libssh2 (I mostly copied the libxml2 puppet module). I installed pkg-config to get curl to link to libssh2 and libssh2 to link to openssl. If pkg-config is simple to set up on the other platforms, then this should be easy to generalize. It's also a bit kludgy right now because I ordered libssh2 after the underlying Exec resource for Autotools['openssl'](I'm not sure if there's a better way to do that with puppet).
