### PR TITLE
Make Vagrant find the embedded "bsdtar" on 64-bit MSYS2

### DIFF
--- a/substrate/modules/vagrant_installer/templates/vagrant.erb
+++ b/substrate/modules/vagrant_installer/templates/vagrant.erb
@@ -66,7 +66,7 @@ RUBY_EXECUTABLE="${EMBEDDED_DIR}/bin/ruby"
 
 # Do some things depending on the OS that we're running on.
 case $OS in
-	CYGWIN* | MINGW32*)
+	CYGWIN* | MINGW32* | MINGW64*)
 		# In Linux-like environments on Windows, we want to add the
 		# Windows path to the PATH so that bsdtar and friends can
 		# be found.


### PR DESCRIPTION
The 64-bit version of MSYS2, which ships with 64-bit Git for Windows 2.x,
returns "MINGW64_NT-6.3" for "uname -s", which does not match "MINGW32*".
Make it match by removing the bitness from the case string.

Fixes mitchellh/vagrant#5871.