### PR TITLE
Fix file permissions for Windows

### DIFF
--- a/package/package.ps1
+++ b/package/package.ps1
@@ -113,7 +113,7 @@ $VagrantVersionFile = Join-Path $VagrantSourceDir version.txt
 if (-Not (Test-Path $VagrantVersionFile)) {
     "0.1.0" | Out-File -FilePath $VagrantVersionFile
 }
-$VagrantVersion=$((Get-Content $VagrantVersionFile) -creplace '\.[^0-9]+$')
+$VagrantVersion=$((Get-Content $VagrantVersionFile) -creplace '\.[^0-9]+(\.[0-9]+)?$', '$1')
 Write-Host "Vagrant version: $VagrantVersion"
 
 # Install gem. We do this in a sub-shell so we don't have to worry

--- a/package/package.ps1
+++ b/package/package.ps1
@@ -25,6 +25,8 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$VagrantRevision,
 
+    [string]$VagrantSourceBaseURL="https://github.com/mitchellh/vagrant/archive/",
+
     [string]$SignKey="",
     [string]$SignKeyPassword="",
     [string]$SignPath=""
@@ -84,7 +86,7 @@ $VagrantTmpDir = [System.IO.Path]::Combine(
 [System.IO.Directory]::CreateDirectory($VagrantTmpDir) | Out-Null
 Write-Host "Vagrant temp dir: $($VagrantTmpDir)"
 
-$VagrantSourceURL = "https://github.com/mitchellh/vagrant/archive/$($VagrantRevision).zip"
+$VagrantSourceURL = "$($VagrantSourceBaseURL)/$($VagrantRevision).zip"
 $VagrantDest      = "$($VagrantTmpDir)\vagrant.zip"
 
 # Download

--- a/substrate/modules/atlas_upload_cli/manifests/init.pp
+++ b/substrate/modules/atlas_upload_cli/manifests/init.pp
@@ -20,5 +20,6 @@ class atlas_upload_cli($install_path) {
 
   file { $install_path:
     source => "puppet:///modules/atlas_upload_cli/${source_filename}/atlas-upload${source_suffix}",
+    mode   => '0755',
   }
 }

--- a/substrate/modules/bsdtar/manifests/windows.pp
+++ b/substrate/modules/bsdtar/manifests/windows.pp
@@ -6,6 +6,7 @@ class bsdtar::windows {
 
   file { $source_file_path:
     source => "puppet:///modules/bsdtar/windows.zip",
+    mode   => '0644',
   }
 
   powershell { "extract-bsdtar":

--- a/substrate/modules/curl/manifests/windows.pp
+++ b/substrate/modules/curl/manifests/windows.pp
@@ -6,6 +6,7 @@ class curl::windows {
 
   file { $source_file_path:
     source => "puppet:///modules/curl/windows.zip",
+    mode   => '0644',
   }
 
   powershell { "extract-curl":

--- a/substrate/modules/ruby/manifests/windows.pp
+++ b/substrate/modules/ruby/manifests/windows.pp
@@ -37,6 +37,7 @@ class ruby::windows(
   file { "${install_dir}/lib/ruby/2.0.0/dl.rb":
     source  => "puppet:///modules/ruby/modified_dl.rb",
     require => Exec["install-ruby"],
+    mode    => '0644',
   }
 
   #------------------------------------------------------------------

--- a/substrate/modules/rubyencoder/manifests/loaders.pp
+++ b/substrate/modules/rubyencoder/manifests/loaders.pp
@@ -22,7 +22,7 @@ class rubyencoder::loaders(
   } else {
     $owner = undef
     $group = undef
-    $mode  = undef
+    $mode  = '0644'
   }
 
   file { "${path}/rgloader":


### PR DESCRIPTION
Hi,

I updated the Puppet scripts so that the substrate archive can be built under Windows 7. In addition, I added a new argument in the MSI package script to allow the user to specify where to download the Vagrant source zip file. This facilitates building an installer from a custom source.

Cheers,
Vince