### PR TITLE
Disable lzo2 for bsdtar

### DIFF
--- a/substrate/modules/bsdtar/manifests/posix.pp
+++ b/substrate/modules/bsdtar/manifests/posix.pp
@@ -9,7 +9,7 @@ class bsdtar::posix {
   $source_package_path = "${file_cache_dir}/libarchive.tar.gz"
   $source_url = "https://github.com/libarchive/libarchive/archive/v3.1.2.tar.gz"
 
-  $configure_flags = "--prefix=${install_dir} --disable-dependency-tracking --with-zlib --without-bz2lib --without-iconv --without-libiconv-prefix --without-nettle --without-openssl --without-xml2 --without-expat --without-libregex"
+  $configure_flags = "--prefix=${install_dir} --disable-dependency-tracking --with-zlib --without-bz2lib --without-iconv --without-libiconv-prefix --without-nettle --without-openssl --without-xml2 --without-expat --without-libregex --without-lzo2"
 
   # We don't currently support LZMA on Linux. TODO
   $real_configure_flags = $operatingsystem ? {


### PR DESCRIPTION
Not sure if this actually hurts anything, but I couldn't get bsdtar to
build on OS X 10.11.1 without disabling lzo2.

Fixes #72 
