### PR TITLE
unset env RUBYLIB to avoid it leaking into vagrant.

### DIFF
--- a/substrate/launcher/main.go
+++ b/substrate/launcher/main.go
@@ -142,6 +142,8 @@ func main() {
 
 	// Unset any RUBYOPT, we don't want this bleeding into our runtime
 	newEnv["RUBYOPT"] = ""
+	// Unset any RUBYLIB, we don't want this bleeding into our runtime
+	newEnv["RUBYLIB"] = ""
 
 	// Store the "current" environment so Vagrant can restore it when shelling
 	// out.


### PR DESCRIPTION
Fixes this issue: https://github.com/mitchellh/vagrant/issues/6158

reproducing steps:

```
bundle init
bundle exec vagrant
Usage: vagrant [options] <command> [<args>]

    -v, --version                    Print the version and exit.
    -h, --help                       Print this help.

Common commands:
     box             manages boxes: installation, removal, etc.
     connect         connect to a remotely shared Vagrant environment
     destroy         stops and deletes all traces of the vagrant machine
     global-status   outputs status Vagrant environments for this user
     halt            stops the vagrant machine
     help            shows the help for a subcommand
     init            initializes a new Vagrant environment by creating a Vagrantfile
     login           log in to HashiCorp's Atlas
     package         packages a running vagrant environment into a box
     plugin          manages plugins: install, uninstall, update, etc.
     port            displays information about guest port mappings
     powershell      connects to machine via powershell remoting
     provision       provisions the vagrant machine
     push            deploys code in this environment to a configured destination
     rdp             connects to machine via RDP
     reload          restarts vagrant machine, loads new Vagrantfile configuration
     resume          resume a suspended vagrant machine
     share           share your Vagrant environment with anyone in the world
     snapshot        manages snapshots: saving, restoring, etc.
     ssh             connects to machine via SSH
     ssh-config      outputs OpenSSH valid configuration to connect to the machine
     status          outputs status of the vagrant machine
     suspend         suspends the machine
     up              starts and provisions the vagrant environment
     version         prints current and latest Vagrant version

For help on any individual command run `vagrant COMMAND -h`

Additional subcommands are available, but are either more advanced
or not commonly used. To see all subcommands, run the command
`vagrant list-commands`.


C:\Users\khm\work\tmp>bundle exec vagrant
Vagrant experienced a version conflict with some installed plugins!
This usually happens if you recently upgraded Vagrant. As part of the
upgrade process, some existing plugins are no longer compatible with
this version of Vagrant. The recommended way to fix this is to remove
your existing plugins and reinstall them one-by-one. To remove all
plugins:

    rm -r ~/.vagrant.d/plugins.json ~/.vagrant.d/gems

Note if you have an alternate VAGRANT_HOME environmental variable
set, the folders above will be in that directory rather than your
user's home directory.

The error message is shown below:

Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    vagrant (= 1.8.1) x86-mingw32 was resolved to 1.8.1, which depends on
      bundler (<= 1.10.6, >= 1.5.2) x86-mingw32

  Current Bundler version:
    bundler (1.11.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (<= 1.10.6, >= 1.5.2) x86-mingw32', which is required by gem 'vagrant (= 1.8.1) x86-mingw32'
, in any of the sources.

C:\Users\khm\work\tmp>


