### PR TITLE
Disable certificate check 

### DIFF
--- a/substrate/modules/wget/manifests/fetch.pp
+++ b/substrate/modules/wget/manifests/fetch.pp
@@ -18,7 +18,7 @@ define wget::fetch($source=$name, $destination) {
   require wget
 
   exec { "wget-${name}":
-    command => "wget --output-document=${destination} ${source}",
+    command => "wget --no-check-certificate --output-document=${destination} ${source}",
     creates => $destination,
     timeout => 1200,
   }


### PR DESCRIPTION
Older distro version cannot properly verify certificates. Verification is disabled elsewhere via calling `http` endpoints, but many now automatically redirect to `https`.