### PR TITLE
Override the hardcoded broken sed path in glibtoolize (OS X fix)

### DIFF
--- a/substrate/modules/bsdtar/manifests/posix.pp
+++ b/substrate/modules/bsdtar/manifests/posix.pp
@@ -79,10 +79,11 @@ class bsdtar::posix {
   #------------------------------------------------------------------
   # Create configuration script
   exec { "automake-libarchive":
-    command => "/bin/sh build/autogen.sh",
-    creates => "${source_dir_path}/configure",
-    cwd     => $source_dir_path,
-    require => Exec["untar-libarchive"],
+    command     => "/bin/sh build/autogen.sh",
+    creates     => "${source_dir_path}/configure",
+    environment => ["SED=/usr/bin/sed"],
+    cwd         => $source_dir_path,
+    require     => Exec["untar-libarchive"],
   }
 
   # Build it


### PR DESCRIPTION
A hardcoded sed path in the automake-libarchive exec block was breaking my build on OS X. This overrides the path to sed using an environment variable and fixes it.
