### PR TITLE
osx linker isolation / 32bit removal

### DIFF
--- a/package/support/install_vagrant.sh
+++ b/package/support/install_vagrant.sh
@@ -65,6 +65,12 @@ export CFLAGS="${CPPFLAGS}"
 export LDFLAGS="-L${EMBEDDED_DIR}/lib"
 export PATH="${EMBEDDED_DIR}/bin:${PATH}"
 export SSL_CERT_FILE="${EMBEDDED_DIR}/cacert.pem"
+
+# Darwin
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export CONFIGURE_ARGS="-Wl,-rpath,${EMBEDDED_DIR}/lib"
+fi
+
 ${GEM_COMMAND} install vagrant.gem --no-ri --no-rdoc
 
 # Install extensions

--- a/substrate/launcher/main.go
+++ b/substrate/launcher/main.go
@@ -145,6 +145,14 @@ func main() {
 	// Unset any RUBYLIB, we don't want this bleeding into our runtime
 	newEnv["RUBYLIB"] = ""
 
+	if runtime.GOOS == "darwin" {
+		configure_args := "-Wl,rpath," + filepath.Join(embeddedDir, "lib")
+		if original_configure_args := os.Getenv("CONFIGURE_ARGS"); original_configure_args != "" {
+			configure_args = original_configure_args + " " + configure_args
+		}
+		newEnv["CONFIGURE_ARGS"] = configure_args
+	}
+
 	// Store the "current" environment so Vagrant can restore it when shelling
 	// out.
 	for _, value := range os.Environ() {

--- a/substrate/modules/openssl/manifests/install/linux.pp
+++ b/substrate/modules/openssl/manifests/install/linux.pp
@@ -14,7 +14,7 @@ class openssl::install::linux {
     configure_sentinel => "${source_dir_path}/apps/CA.pl.bak",
     cwd                => $source_dir_path,
     environment        => $autotools_environment,
-    install_sentinel   => "${prefix}/lib/libssl.so",
+    install_sentinel   => "${prefix}/bin/openssl",
     make_notify        => $make_notify,
     make_sentinel      => "${source_dir_path}/libssl.a",
     require            => Exec["untar-openssl"],

--- a/substrate/modules/ruby/manifests/source.pp
+++ b/substrate/modules/ruby/manifests/source.pp
@@ -16,8 +16,11 @@ class ruby::source(
   $source_dir_name  = regsubst($source_filename, '^(.+?)\.tar\.gz$', '\1')
   $source_dir_path  = "${file_cache_dir}/${source_dir_name}"
 
+  $lib_short_version = "2.2"
+  $lib_long_version = "2.2.0"
+
   if $operatingsystem == 'Darwin' {
-    $extra_configure_flags = ' --with-arch=x86_64,i386'
+    $extra_configure_flags = ' --with-arch=x86_64'
   }
 
   # OS-specific environment vars
@@ -88,15 +91,44 @@ class ruby::source(
 
   # On Darwin we have to clean up some paths
   if $kernel == 'Darwin' {
+    $libruby_paths = [
+      "${prefix}/lib/libruby.dylib",
+      "${prefix}/lib/libruby.${lib_short_version}.dylib",
+      "${prefix}/lib/libruby.${lib_long_version}.dylib",
+    ]
+    $lib_path = "@rpath/libruby.${lib_long_version}.dylib"
+    $original_lib_path = "@executable_path/../lib/libruby.${lib_long_version}.dylib"
+    $embedded_dir = "${prefix}/lib"
+
+    vagrant_substrate::staging::darwin_rpath { $libruby_paths:
+      new_lib_path => $lib_path,
+      remove_rpath => $embedded_dir,
+      require => Autotools["ruby"],
+      subscribe => Autotools["ruby"],
+    }
+
+    vagrant_substrate::staging::darwin_rpath { "${prefix}/bin/ruby":
+      change_install_names => {
+        libruby => {
+          original => $original_lib_path,
+          replacement => $lib_path,
+        },
+      },
+      new_lib_path => $lib_path,
+      remove_rpath => $embedded_dir,
+      require => Autotools["ruby"],
+      subscribe => Autotools["ruby"],
+    }
+
     exec { "remove-ruby-bundle-rpaths":
-      command     => "find ${prefix}/lib/ruby -type f -name '*.bundle' | xargs -n1 install_name_tool -delete_rpath ${prefix}/lib",
+      command     => "find ${prefix}/lib/ruby -type f -name '*.bundle' -exec install_name_tool -delete_rpath ${embedded_dir} {} \\;",
       refreshonly => true,
       require     => Autotools["ruby"],
       subscribe   => Autotools["ruby"],
     }
 
-    exec { "remove-ruby-rpaths":
-      command     => "install_name_tool -delete_rpath ${prefix}/lib ${prefix}/bin/ruby",
+    exec { "modify-ruby-bundle-link-names":
+      command     => "find ${prefix}/lib/ruby -type f -name '*.bundle' -exec install_name_tool -change ${original_lib_path} ${lib_path} {} \\;",
       refreshonly => true,
       require     => Autotools["ruby"],
       subscribe   => Autotools["ruby"],

--- a/substrate/modules/vagrant_substrate/manifests/staging/darwin_rpath.pp
+++ b/substrate/modules/vagrant_substrate/manifests/staging/darwin_rpath.pp
@@ -1,0 +1,59 @@
+# == Define: vagrant_substrate::staging::darwin_rpath
+#
+# A helper to set proper rpath information on darwin
+#
+define vagrant_substrate::staging::darwin_rpath(
+  $add_rpath=[
+    "@loader_path/../lib",
+    "@executable_path/../lib"
+  ],
+  $change_install_names={},
+  $new_lib_path,
+  $remove_rpath,
+  $target_file_path=$name,
+) {
+
+  # Always set the header ID. If it is not applicable to the target file
+  # given, it will simply be a no-op
+  exec { "set-${name}-id":
+    command => "install_name_tool -id ${new_lib_path} ${target_file_path}",
+  }
+
+  create_resources(
+    vagrant_substrate::staging::darwin_name_change,
+    $change_install_names,
+    { target_file_path => $target_file_path }
+  )
+
+  $add_rpath_stringify = join($add_rpath, "<${target_file_path}>,")
+  $hacky_add_rpath = split("${add_rpath_stringify}<${target_file_path}>", ",")
+  vagrant_substrate::staging::darwin_add_rpath { $hacky_add_rpath:
+    target_file_path => $target_file_path,
+  }
+
+  exec { "remove-${name}-rpath":
+    command => "install_name_tool -delete_rpath ${remove_rpath} ${target_file_path}",
+    onlyif => "otool -l ${target_file_path} | grep 'path ${remove_rpath}'"
+  }
+}
+
+define vagrant_substrate::staging::darwin_name_change(
+  $original,
+  $replacement,
+  $target_file_path,
+) {
+  exec { "change-${name}-${original}":
+    command => "install_name_tool -change ${original} ${replacement} ${target_file_path}",
+  }
+}
+
+define vagrant_substrate::staging::darwin_add_rpath(
+  $new_rpath=$name,
+  $target_file_path
+) {
+  $clean_rpath = regsubst($new_rpath, regexpescape("<${target_file_path}>"), "")
+  exec { "new-rpath-${name}-${target_file_path}":
+    command => "install_name_tool -add_rpath ${clean_rpath} ${target_file_path}",
+    unless => "otool -l ${target_file_path} | grep 'path ${clean_rpath}'"
+  }
+}

--- a/substrate/modules/vagrant_substrate/manifests/staging/posix.pp
+++ b/substrate/modules/vagrant_substrate/manifests/staging/posix.pp
@@ -61,6 +61,14 @@ class vagrant_substrate::staging::posix {
       "LDFLAGS" => "-Wl,-rpath,@loader_path/../lib -Wl,-rpath,@executable_path/../lib",
     }
 
+    $openssl_autotools_environment = {
+      "LDFLAGS" => "-Wl,-rpath,@loader_path/../lib -Wl,-rpath,@executable_path/../lib",
+    }
+
+    $libssh2_autotools_environment = {
+      "LDFLAGS" => "-Wl,-install_name,@rpath/libssh2.dylib -Wl,-rpath,@loader_path/../lib -Wl,-rpath,@executable_path/../lib",
+    }
+
     $xz_autotools_environment = {
       "LDFLAGS" => "-Wl,-install_name,@rpath/liblzma.dylib",
     }
@@ -151,14 +159,16 @@ class vagrant_substrate::staging::posix {
   }
 
   class { "openssl":
-    autotools_environment => $default_autotools_environment,
+    autotools_environment => autotools_merge_environments(
+      $default_autotools_environment, $openssl_autotools_environment),
     file_cache_dir        => $cache_dir,
     prefix                => $embedded_dir,
     make_notify           => Exec["reset-ruby"],
   }
 
   class { "libssh2":
-    autotools_environment => $default_autotools_environment,
+    autotools_environment => autotools_merge_environments(
+      $default_autotools_environment, $libssh2_autotools_environment),
     file_cache_dir        => $cache_dir,
     prefix                => $embedded_dir,
     require               => Class["openssl"],

--- a/substrate/modules/xz/manifests/init.pp
+++ b/substrate/modules/xz/manifests/init.pp
@@ -16,12 +16,14 @@ class xz(
   $source_dir_name  = regsubst($source_filename, '^(.+?)\.tar\.gz$', '\1')
   $source_dir_path  = "${file_cache_dir}/${source_dir_name}"
 
+  $lib_version = "5"
+
   # Determine if we have an extra environmental variables we need to set
   # based on the operating system.
   if $operatingsystem == 'Darwin' {
     $extra_autotools_environment = {
-      "CFLAGS"  => "-arch i386 -arch x86_64",
-      "LDFLAGS" => "-arch i386 -arch x86_64",
+      "CFLAGS"  => "-arch x86_64",
+      "LDFLAGS" => "-arch x86_64",
     }
   } else {
     $extra_autotools_environment = {}
@@ -54,5 +56,21 @@ class xz(
     make_notify      => $make_notify,
     make_sentinel    => "${source_dir_path}/liblzma/.libs/liblzma.a",
     require          => Exec["untar-xz"],
+  }
+
+  if $kernel == 'Darwin' {
+    $libxz_paths = [
+      "${prefix}/lib/liblzma.dylib",
+      "${prefix}/lib/liblzma.${lib_version}.dylib",
+    ]
+    $lib_path = "@rpath/liblzma.${lib_version}.dylib"
+    $embedded_dir = "${prefix}/lib"
+
+    vagrant_substrate::staging::darwin_rpath { $libxz_paths:
+      new_lib_path => $lib_path,
+      remove_rpath => $embedded_dir,
+      require => Autotools["xz"],
+      subscribe => Autotools["xz"],
+    }
   }
 }


### PR DESCRIPTION
This changeset removes 32bit builds for darwin. It also updates linking within the substrate to be more dynamic. The modification provides better behavior on relocation and fixes issues like mitchellh/vagrant#7747 where the bin file within the substrate is attempting to use a static path.

The wrapper also customizes the `CONFIGURE_ARGS` environment variable to ensure that the correct rpath is included when C extensions are built.