### PR TITLE
Substrate updates

### DIFF
--- a/substrate/modules/homebrew/manifests/package.pp
+++ b/substrate/modules/homebrew/manifests/package.pp
@@ -16,6 +16,7 @@ define homebrew::package(
     creates     => $creates,
     environment => "HOME=/Users/${user}",
     user        => $user,
+    timeout     => 1200
   }
 
   if $link {

--- a/substrate/modules/libssh2/manifests/init.pp
+++ b/substrate/modules/libssh2/manifests/init.pp
@@ -55,7 +55,10 @@ class libssh2(
     install_sentinel => "${prefix}/lib/libssh2.a",
     make_notify      => $make_notify,
     make_sentinel    => "${source_dir_path}/.libs/libssh2.a",
-    require          => Exec["untar-libssh2"],
+    require          => [
+      Exec["untar-libssh2"],
+      Autotools["openssl"],
+    ],
   }
 
   if $kernel == 'Darwin' {

--- a/substrate/modules/openssl/manifests/install/darwin.pp
+++ b/substrate/modules/openssl/manifests/install/darwin.pp
@@ -40,7 +40,7 @@ class openssl::install::darwin {
   # can get the headers and all that properly into the final directory.
   # We replace the libraries it would install with our own universal
   # binaries later in the process.
-  autotools { "openssl-64":
+  autotools { "openssl":
     configure_file     => "./Configure",
     configure_flags    => "--prefix=${prefix} shared darwin64-x86_64-cc",
     configure_sentinel => "${openssl_64_path}/apps/CA.pl.bak",
@@ -65,8 +65,8 @@ class openssl::install::darwin {
   vagrant_substrate::staging::darwin_rpath { [$libcrypto_path, $libcrypto_stub_path]:
     new_lib_path => $new_crypto_rpath,
     remove_rpath => $embedded_libdir,
-    require => Autotools["openssl-64"],
-    subscribe => Autotools["openssl-64"],
+    require => Autotools["openssl"],
+    subscribe => Autotools["openssl"],
   }
 
   vagrant_substrate::staging::darwin_rpath { $libssl_path:
@@ -78,8 +78,8 @@ class openssl::install::darwin {
     },
     new_lib_path => $new_ssl_rpath,
     remove_rpath => $embedded_libdir,
-    require => Autotools["openssl-64"],
-    subscribe => Autotools["openssl-64"],
+    require => Autotools["openssl"],
+    subscribe => Autotools["openssl"],
   }
 
   vagrant_substrate::staging::darwin_rpath { $libssl_stub_path:
@@ -91,8 +91,8 @@ class openssl::install::darwin {
     },
     new_lib_path => $new_ssl_rpath,
     remove_rpath => $embedded_libdir,
-    require => Autotools["openssl-64"],
-    subscribe => Autotools["openssl-64"],
+    require => Autotools["openssl"],
+    subscribe => Autotools["openssl"],
   }
 
 
@@ -109,7 +109,7 @@ class openssl::install::darwin {
     },
     new_lib_path => $openssl_path,
     remove_rpath => $embedded_libdir,
-    require => Autotools["openssl-64"],
-    subscribe => Autotools["openssl-64"],
+    require => Autotools["openssl"],
+    subscribe => Autotools["openssl"],
   }
 }

--- a/substrate/run.ps1
+++ b/substrate/run.ps1
@@ -30,10 +30,17 @@ $arguments = @(
     "apply",
     "--confdir=$TmpDir",
     "--modulepath=$($Dir)/modules",
+    "--detailed-exitcodes",
     "$($Dir)/manifests/init.pp"
 )
 
 $path = "C:\Program Files (x86)\Puppet Labs\Puppet\bin\puppet.bat"
 
 Set-Location $Dir
-Start-Process -NoNewWindow -Wait -ArgumentList $arguments -FilePath $path
+$result = Start-Process -NoNewWindow -Wait -ArgumentList $arguments -FilePath $path
+
+if($result.ExitCode -ne 0 -And $result.ExitCode -ne 2){
+  Exit $result.ExitCode
+} else {
+  Exit 0
+}

--- a/substrate/run.sh
+++ b/substrate/run.sh
@@ -24,7 +24,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # from a filesystem that doesn't support that (VMWare shared folders),
 # then Puppet will fail.
 TMP_CONFIG_DIR=$(mktemp -d -t vagrant-installer.XXXXXX)
-cp -R ${DIR}/config/* ${TMP_CONFIG_DIR}
+cp -R "${DIR}/config/"* ${TMP_CONFIG_DIR}
 
 # Setup the output directory
 mkdir -p $1
@@ -33,9 +33,17 @@ mkdir -p $1
 export FACTER_param_homebrew_user=${SUDO_USER}
 export FACTER_param_output_dir=$(cd $1; pwd)
 
+export TERM="vt100"
+export LANG="en_US.UTF-8"
+
 # Invoke Puppet
-cd $DIR
+cd "${DIR}"
 puppet apply \
   --confdir=${TMP_CONFIG_DIR} \
-  --modulepath=${DIR}/modules \
-  ${DIR}/manifests/init.pp
+  --modulepath="${DIR}/modules" \
+  --detailed-exitcodes \
+  "${DIR}/manifests/init.pp"
+
+puppet_result=$?
+(test $puppet_result -eq 0 || test $puppet_result -eq 2) && exit 0
+exit $puppet_result


### PR DESCRIPTION
Updates substrate runners to return exit codes based on expected success (built substrate). Require openssl before build libssh2. Set higher timeout on package install to prevent errors on slower connections.