### PR TITLE
Replace rpath to remove if possible

### DIFF
--- a/substrate/modules/vagrant_substrate/manifests/staging/darwin_rpath.pp
+++ b/substrate/modules/vagrant_substrate/manifests/staging/darwin_rpath.pp
@@ -25,6 +25,11 @@ define vagrant_substrate::staging::darwin_rpath(
     { target_file_path => $target_file_path }
   )
 
+  exec { "change-${name}-rpath":
+    command => "install_name_tool -rpath ${remove_rpath} ${add_rpath[0]} ${target_file_path}",
+    onlyif => "otool -l ${target_file_path} | grep 'path ${remove_rpath}'"
+  }
+
   $add_rpath_stringify = join($add_rpath, "<${target_file_path}>,")
   $hacky_add_rpath = split("${add_rpath_stringify}<${target_file_path}>", ",")
   vagrant_substrate::staging::darwin_add_rpath { $hacky_add_rpath:


### PR DESCRIPTION
If the rpath to remove is available, replace it with an rpath
that is to be added to the target file. This prevents errors as
seen with the curl library where simply adding and removing rpaths
would cause a command load error within the library.

Fixes: mitchellh/vagrant#7969