### PR TITLE
Fix library and configuration paths (linux)

### DIFF
--- a/substrate/hiera/common.yaml
+++ b/substrate/hiera/common.yaml
@@ -1,3 +1,4 @@
 ---
+installation_dir: "/opt/vagrant"
 vagrant_substrate::build_dir: "/vagrant-substrate"
 vagrant_substrate::installer_version: "2"

--- a/substrate/hiera/windows.yaml
+++ b/substrate/hiera/windows.yaml
@@ -1,2 +1,3 @@
 ---
+installation_dir: "C:\\HashiCorp\\Vagrant"
 vagrant_substrate::build_dir: "C:\\vagrant-substrate"

--- a/substrate/modules/bsdtar/manifests/posix.pp
+++ b/substrate/modules/bsdtar/manifests/posix.pp
@@ -113,4 +113,17 @@ class bsdtar::posix {
       subscribe => Autotools["libarchive"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libarchive_paths = [
+      "${install_dir}/lib/libarchive.so",
+      "${install_dir}/bin/bsdtar",
+      "${install_dir}/bin/bsdcpio",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libarchive_paths:
+      require => Autotools["libarchive"],
+      subscribe => Autotools["libarchive"],
+    }
+  }
 }

--- a/substrate/modules/curl/manifests/posix.pp
+++ b/substrate/modules/curl/manifests/posix.pp
@@ -23,7 +23,6 @@ class curl::posix {
     }
   } else {
     $extra_autotools_environment = {
-      "LD_RUN_PATH" => "${install_dir}/lib",
     }
   }
 
@@ -88,11 +87,14 @@ class curl::posix {
 
   if $kernel == 'Linux' {
     # We need to clean up the rpaths...
-    exec { "curl-rpath":
-      command => "chrpath -r '\${ORIGIN}/../lib' ${install_dir}/bin/curl",
-      refreshonly => true,
-      require     => Autotools["curl"],
-      subscribe   => Autotools["curl"],
+    $libcurl_paths = [
+      "${install_dir}/bin/curl",
+      "${install_dir}/lib/libcurl.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libcurl_paths:
+      require => Autotools["curl"],
+      subscribe => Autotools["curl"],
     }
   }
 }

--- a/substrate/modules/libffi/manifests/init.pp
+++ b/substrate/modules/libffi/manifests/init.pp
@@ -92,4 +92,15 @@ class libffi (
       subscribe => Autotools["libffi"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libffi_paths = [
+      "${prefix}/lib/libffi.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libffi_paths:
+      require => Autotools["libffi"],
+      subscribe => Autotools["libffi"],
+    }
+  }
 }

--- a/substrate/modules/libiconv/manifests/init.pp
+++ b/substrate/modules/libiconv/manifests/init.pp
@@ -93,4 +93,17 @@ class libiconv(
       subscribe => Autotools["libiconv"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libiconv_paths = [
+      "${prefix}/bin/iconv",
+      "${prefix}/lib/libiconv.so",
+      "${prefix}/lib/libcharset.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libiconv_paths:
+      require => Autotools["libiconv"],
+      subscribe => Autotools["libiconv"],
+    }
+  }
 }

--- a/substrate/modules/libssh2/manifests/init.pp
+++ b/substrate/modules/libssh2/manifests/init.pp
@@ -76,4 +76,15 @@ class libssh2(
       subscribe => Autotools["libssh2"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libssh2_paths = [
+      "${prefix}/lib/libssh2.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libssh2_paths:
+      require => Autotools["libssh2"],
+      subscribe => Autotools["libssh2"],
+    }
+  }
 }

--- a/substrate/modules/libxml2/manifests/init.pp
+++ b/substrate/modules/libxml2/manifests/init.pp
@@ -49,7 +49,7 @@ class libxml2(
   }
 
   autotools { "libxml2":
-    configure_flags  => "--prefix=${prefix} --disable-dependency-tracking --without-python --without-lzma",
+    configure_flags  => "--prefix=${prefix} --disable-dependency-tracking --without-python --without-lzma --with-zlib=${prefix}",
     cwd              => $source_dir_path,
     environment      => $real_autotools_environment,
     install_sentinel => "${prefix}/lib/libxml2.a",
@@ -71,6 +71,19 @@ class libxml2(
     vagrant_substrate::staging::darwin_rpath { $libxml2_paths:
       new_lib_path => $lib_path,
       remove_rpath => $embedded_dir,
+      require => Autotools["libxml2"],
+      subscribe => Autotools["libxml2"],
+    }
+  }
+
+  if $kernel == 'Linux' {
+    $libxml2_paths = [
+      "${prefix}/lib/libxml2.so",
+      "${prefix}/bin/xmlcatalog",
+      "${prefix}/bin/xmllint",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libxml2_paths:
       require => Autotools["libxml2"],
       subscribe => Autotools["libxml2"],
     }

--- a/substrate/modules/libxslt/manifests/init.pp
+++ b/substrate/modules/libxslt/manifests/init.pp
@@ -74,4 +74,16 @@ class libxslt(
       subscribe => Autotools["libxslt"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libxslt_paths = [
+      "${prefix}/bin/xsltproc",
+      "${prefix}/lib/libxslt.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libxslt_paths:
+      require => Autotools["libxslt"],
+      subscribe => Autotools["libxslt"],
+    }
+  }
 }

--- a/substrate/modules/libyaml/manifests/init.pp
+++ b/substrate/modules/libyaml/manifests/init.pp
@@ -73,4 +73,15 @@ class libyaml(
       subscribe => Autotools["libyaml"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libyaml_paths = [
+      "${prefix}/lib/libyaml.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libyaml_paths:
+      require => Autotools["libyaml"],
+      subscribe => Autotools["libyaml"],
+    }
+  }
 }

--- a/substrate/modules/readline/manifests/init.pp
+++ b/substrate/modules/readline/manifests/init.pp
@@ -83,4 +83,15 @@ class readline(
       subscribe => Autotools["readline"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libreadline_paths = [
+      "${prefix}/lib/libreadline.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libreadline_paths:
+      require => Autotools["readline"],
+      subscribe => Autotools["readline"],
+    }
+  }
 }

--- a/substrate/modules/vagrant_substrate/manifests/post_staging/posix.pp
+++ b/substrate/modules/vagrant_substrate/manifests/post_staging/posix.pp
@@ -2,6 +2,7 @@ class vagrant_substrate::post_staging::posix {
   include vagrant_substrate
 
   $embedded_dir = $vagrant_substrate::embedded_dir
+  $installation_dir = hiera("installation_dir")
 
   exec { "clear-openssl-man":
     command => "rm -rf ${embedded_dir}/ssl/man",
@@ -23,5 +24,34 @@ class vagrant_substrate::post_staging::posix {
   # with libtool later because they have hardcoded temp paths in them.
   exec { "remove-la-files":
     command => "rm -rf ${embedded_dir}/lib/*.la",
+  }
+
+  $new_rpath = "\$ORIGIN/../lib:${installation_dir}/embedded/lib"
+  exec { "replace-so-rpaths":
+    command => "find ${embedded_dir}/{lib64,lib/*}/ -name '*.so' -exec chrpath --replace '${new_rpath}' {} \\;",
+    onlyif => "ls ${embedded_dir}/lib64",
+  }
+
+  exec { "replace-so-rpaths-constrained":
+    command => "find ${embedded_dir}/lib/*/ -name '*.so' -exec chrpath --replace '${new_rpath}' {} \\;",
+    unless => "ls ${embedded_dir}/lib64",
+  }
+
+  exec { "convert-so-runpaths":
+    command => "find ${embedded_dir}/{lib64,lib/*}/ -name '*.so' -exec chrpath --convert {} \\;",
+    subscribe => Exec["replace-so-rpaths"],
+    refreshonly => true,
+  }
+
+  exec { "convert-so-runpaths-constrained":
+    command => "find ${embedded_dir}/lib/*/ -name '*.so' -exec chrpath --convert {} \\;",
+    subscribe => Exec["replace-so-rpaths-constrained"],
+    refreshonly => true
+  }
+
+  $destination_dir = "${installation_dir}/embedded"
+  exec { "scrub-substrate-paths":
+    command => "grep -l -I -R '${embedded_dir}' '${embedded_dir}' | xargs sed -i 's@${embedded_dir}@${destination_dir}@g'",
+    onlyif => "grep -l -I -R '${embedded_dir}' '${embedded_dir}'",
   }
 }

--- a/substrate/modules/vagrant_substrate/manifests/staging/linux_chrpath.pp
+++ b/substrate/modules/vagrant_substrate/manifests/staging/linux_chrpath.pp
@@ -1,0 +1,21 @@
+# == Define: vagrant_substrate::staging::linux_chrpath
+#
+# A helper to set proper RUN_PATH information on Linux
+#
+define vagrant_substrate::staging::linux_chrpath(
+  $new_rpath='$ORIGIN/../lib:/opt/vagrant/embedded/lib',
+  $target_file_path=$name,
+) {
+
+  exec { "set-${name}-rpath":
+    command => "chrpath --replace '${new_rpath}' '${target_file_path}'",
+    onlyif => "chrpath --list '${target_file_path}' | grep RPATH",
+  }
+
+  exec { "convert-${name}-runpath":
+    command => "chrpath --convert '${target_file_path}'",
+    onlyif => "chrpath '${target_file_path}' | grep RPATH",
+    subscribe => Exec["set-${name}-rpath"],
+  }
+
+}

--- a/substrate/modules/vagrant_substrate/manifests/staging/posix.pp
+++ b/substrate/modules/vagrant_substrate/manifests/staging/posix.pp
@@ -9,23 +9,17 @@ class vagrant_substrate::staging::posix {
   #------------------------------------------------------------------
   # Calculate variables based on operating system
   #------------------------------------------------------------------
-  $extra_autotools_ldflags = $operatingsystem ? {
-    'Darwin' => "",
-    default  => '',
+  $extra_autotools_ldflags = $kernel ? {
+    "Darwin" => "",
+    "Linux" => "-Wl,-rpath=XORIGIN/../lib:${embedded_dir}/lib",
+    default  => "",
   }
 
   $default_autotools_environment = {
-    "CFLAGS"                   =>
-      "-I${embedded_dir}/include",
-    "LDFLAGS"                  =>
-      "-L${embedded_dir}/lib ${extra_autotools_ldflags}",
+    "CFLAGS" => "-I${embedded_dir}/include",
+    "LDFLAGS" => "-L${embedded_dir}/lib ${extra_autotools_ldflags}",
     "MACOSX_DEPLOYMENT_TARGET" => "10.5",
-  }
-
-  $default_curl_autotools_environment = {
-    "CPPFLAGS"                 => "-I${embedded_dir}/include",
-    "LDFLAGS"                  => "-L${embedded_dir}/lib ${extra_autotools_ldflags}",
-    "MACOSX_DEPLOYMENT_TARGET" => "10.5",
+    "LD_RPATH" => "${embedded_dir}/lib:XORIGIN/../lib",
   }
 
   if $operatingsystem == 'Darwin' {
@@ -78,11 +72,9 @@ class vagrant_substrate::staging::posix {
     }
   } elsif $kernel == 'Linux' {
     $bsdtar_autotools_environment = {
-      "LD_RUN_PATH" => '$ORIGIN/../lib',
     }
 
     $ruby_autotools_environment = {
-      "LD_RUN_PATH" => '\$ORIGIN/../lib',
     }
   }
 
@@ -187,10 +179,11 @@ class vagrant_substrate::staging::posix {
 
   class { "curl":
     autotools_environment => autotools_merge_environments(
-      $default_curl_autotools_environment, $curl_autotools_environment),
+      $default_autotools_environment, $curl_autotools_environment),
     file_cache_dir        => $cache_dir,
     install_dir           => $embedded_dir,
     require               => [
+      Class["libssh2"],
       Class["openssl"],
       Class["zlib"],
     ],

--- a/substrate/modules/xz/manifests/init.pp
+++ b/substrate/modules/xz/manifests/init.pp
@@ -73,4 +73,15 @@ class xz(
       subscribe => Autotools["xz"],
     }
   }
+
+  if $kernel == 'Linux' {
+    $libxz_paths = [
+      "${prefix}/lib/liblzma.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libxz_paths:
+      require => Autotools["xz"],
+      subscribe => Autotools["xz"],
+    }
+  }
 }

--- a/substrate/modules/zlib/manifests/init.pp
+++ b/substrate/modules/zlib/manifests/init.pp
@@ -10,13 +10,13 @@ class zlib(
 ) {
   require build_essential
 
-  $source_filename  = "zlib-1.2.8.tar.gz"
+  $source_filename  = "zlib-1.2.11.tar.gz"
   $source_url = "http://zlib.net/${source_filename}"
   $source_file_path = "${file_cache_dir}/${source_filename}"
   $source_dir_name  = regsubst($source_filename, '^(.+?)\.tar\.gz$', '\1')
   $source_dir_path  = "${file_cache_dir}/${source_dir_name}"
 
-  $lib_version = "1.2.8"
+  $lib_version = "1.2.11"
   $lib_short_version = "1"
 
   # Determine if we have an extra environmental variables we need to set
@@ -72,6 +72,17 @@ class zlib(
     vagrant_substrate::staging::darwin_rpath { $libz_paths:
       new_lib_path => $lib_path,
       remove_rpath => $embedded_dir,
+      require => Autotools["libz"],
+      subscribe => Autotools["libz"],
+    }
+  }
+
+  if $kernel == 'Linux' {
+    $libz_paths = [
+      "${prefix}/lib/libz.so",
+    ]
+
+    vagrant_substrate::staging::linux_chrpath{ $libz_paths:
       require => Autotools["libz"],
       subscribe => Autotools["libz"],
     }


### PR DESCRIPTION
Update all linux library and configuration paths to ensure proper functionality when relocated (installed via installer).

Fixes: mitchellh/vagrant#6721, mitchellh/vagrant#8184